### PR TITLE
Add abstract as a reserved keyword

### DIFF
--- a/Crystal.tmLanguage
+++ b/Crystal.tmLanguage
@@ -192,7 +192,7 @@
 			<key>comment</key>
 			<string>everything being a reserved word, not a value and needing a 'end' is a..</string>
 			<key>match</key>
-			<string>(?&lt;!\.)\b(BEGIN|alias|as|begin|case|class|else|elsif|END|end|ensure|for|fun|if|ifdef|in|lib|module|of|out|rescue|struct|then|type|unless|until|when|while)\b(?![?!])</string>
+			<string>(?&lt;!\.)\b(BEGIN|alias|as|begin|case|abstract|class|else|elsif|END|end|ensure|for|fun|if|ifdef|in|lib|module|of|out|rescue|struct|then|type|unless|until|when|while)\b(?![?!])</string>
 			<key>name</key>
 			<string>keyword.control.crystal</string>
 		</dict>


### PR DESCRIPTION
To support class highlighting like this one:

``` ruby
# Base class for nodes in the grammar.
abstract class ASTNode
  property location

  def clone
    clone = clone_without_location
    clone.location = location
    clone
  end

  def name_column_number
    @location ? @location.column_number : nil
  end

  def name_length
    nil
  end

  def nop?
    false
  end

  def to_s_for_macro
    to_s
  end
end
```
