### PR TITLE
Adds __DIR__ as recognized special variable

### DIFF
--- a/Crystal.tmLanguage
+++ b/Crystal.tmLanguage
@@ -343,7 +343,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b(__(FILE|LINE)__|self)\b(?![?!])</string>
+			<string>\b(__(DIR|FILE|LINE)__|self)\b(?![?!])</string>
 			<key>name</key>
 			<string>variable.language.crystal</string>
 		</dict>


### PR DESCRIPTION
Missing `__DIR__` was not properly highlighted as part of the language syntax.

This change ensures it receives the same treatment as `__FILE__` and `__LINE__`.

Thank you. :heart: :heart: :heart: 