### PR TITLE
Remove Ruby block comment (`=begin` and `=end`)

### DIFF
--- a/Crystal.tmLanguage
+++ b/Crystal.tmLanguage
@@ -58,7 +58,6 @@
 	        |case
 	        |begin
 	        |for|while|until
-	         |^=begin
 	        |(  "(\\.|[^"])*+"          # eat a double quoted string
 	         | '(\\.|[^'])*+'        # eat a single quoted string
 	         |   [^#"']                # eat all but comments and strings
@@ -1633,24 +1632,6 @@
 			<string>(?&gt;[a-zA-Z_\x{80}-\x{10FFFF}][\w\x{80}-\x{10FFFF}]*(?&gt;[?!])?)(:)(?!:)</string>
 			<key>name</key>
 			<string>constant.other.symbol.crystal.19syntax</string>
-		</dict>
-		<dict>
-			<key>begin</key>
-			<string>^=begin</string>
-			<key>captures</key>
-			<dict>
-				<key>0</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.definition.comment.crystal</string>
-				</dict>
-			</dict>
-			<key>comment</key>
-			<string>multiline comments</string>
-			<key>end</key>
-			<string>^=end</string>
-			<key>name</key>
-			<string>comment.block.documentation.crystal</string>
 		</dict>
 		<dict>
 			<key>captures</key>

--- a/preferences/Comments.tmPreferences
+++ b/preferences/Comments.tmPreferences
@@ -18,17 +18,9 @@
 			</dict>
 			<dict>
 				<key>name</key>
-				<string>TM_COMMENT_START_2</string>
+				<string>TM_COMMENT_MODE</string>
 				<key>value</key>
-				<string>=begin
-</string>
-			</dict>
-			<dict>
-				<key>name</key>
-				<string>TM_COMMENT_END_2</string>
-				<key>value</key>
-				<string>=end
-</string>
+				<string>line</string>
 			</dict>
 		</array>
 	</dict>

--- a/snippets/RDoc-documentation-block.sublime-snippet
+++ b/snippets/RDoc-documentation-block.sublime-snippet
@@ -1,8 +1,0 @@
-<snippet>
-    <content><![CDATA[`[[ $TM_LINE_INDEX != 0 ]] && echo; echo`=begin rdoc
-	$0
-=end]]></content>
-    <tabTrigger>=b</tabTrigger>
-    <scope>source.crystal</scope>
-    <description>New Block</description>
-</snippet>


### PR DESCRIPTION
This removes `=begin` and `=end` block comment from the language description and configures the block comment command to use single line comment `# ` for multiple lines.